### PR TITLE
Fix version string

### DIFF
--- a/cedargrove_rangeslicer.py
+++ b/cedargrove_rangeslicer.py
@@ -18,7 +18,7 @@ Implementation Notes
     https://github.com/adafruit/circuitpython/releases
 """
 
-__version__ = "0.0.0-auto.0"
+__version__ = "0.0.0+auto.0"
 __repo__ = "https://github.com/CedarGroveStudios/Range_Slicer.git"
 
 


### PR DESCRIPTION
I thought this was fixed in the cookiecutter, but this is the fix needed if you want PyPI packages to be able to have the current version of `__version__` when releasing.  Might be worth checking the other recent Community Bundle libraries you've submitted too, if that matters for you!